### PR TITLE
Add fifteen high compliance SQL audit scripts

### DIFF
--- a/high-compliance/check-auditing-status.sql
+++ b/high-compliance/check-auditing-status.sql
@@ -1,0 +1,18 @@
+/*
+    check-auditing-status.sql
+    Lists configured server audits with detailed information.
+
+    Refs: PCI DSS 10.2, ISO 27001 A.12.4
+*/
+SELECT
+    audit_guid,
+    name AS AuditName,
+    type_desc,
+    on_failure_desc,
+    is_state_enabled,
+    queue_delay,
+    audit_file_path,
+    predicate,
+    create_date,
+    modify_date
+FROM sys.server_audits;

--- a/high-compliance/check-guest-user-status.sql
+++ b/high-compliance/check-guest-user-status.sql
@@ -1,0 +1,18 @@
+/*
+    check-guest-user-status.sql
+    Shows whether the guest user is disabled in the current database with extra metadata.
+
+    Refs: CIS SQL Server 2.1
+*/
+SELECT
+    DB_NAME() AS DatabaseName,
+    dp.principal_id,
+    dp.name AS PrincipalName,
+    dp.type_desc,
+    dp.authentication_type_desc,
+    dp.default_schema_name,
+    dp.create_date,
+    dp.modify_date,
+    dp.is_disabled
+FROM sys.database_principals AS dp
+WHERE dp.name = 'guest';

--- a/high-compliance/cross-database-ownership-chaining.sql
+++ b/high-compliance/cross-database-ownership-chaining.sql
@@ -1,0 +1,20 @@
+/*
+    cross-database-ownership-chaining.sql
+    Identifies databases with cross-database ownership chaining enabled.
+
+    Refs: CIS SQL Server 3.3
+*/
+SELECT
+    name AS DatabaseName,
+    database_id,
+    containment_desc,
+    state_desc,
+    owner_sid,
+    create_date,
+    is_db_chaining_on,
+    is_trustworthy_on,
+    is_broker_enabled,
+    user_access_desc,
+    recovery_model_desc
+FROM sys.databases
+WHERE is_db_chaining_on = 1;

--- a/high-compliance/database-mail-profile-security.sql
+++ b/high-compliance/database-mail-profile-security.sql
@@ -1,0 +1,22 @@
+/*
+    database-mail-profile-security.sql
+    Shows which principals have access to Database Mail profiles with expanded details.
+
+    Refs: HIPAA 164.312(b)
+*/
+SELECT
+    p.profile_id,
+    p.name AS ProfileName,
+    p.description,
+    sp.principal_id,
+    sp.name AS PrincipalName,
+    sp.type_desc AS PrincipalType,
+    sp.is_disabled,
+    sp.create_date,
+    sp.default_database_name,
+    pp.is_default AS IsDefault
+FROM msdb.dbo.sysmail_principalprofile AS pp
+JOIN msdb.dbo.sysmail_profile AS p
+    ON pp.profile_id = p.profile_id
+LEFT JOIN sys.server_principals AS sp
+    ON pp.principal_id = sp.principal_id;

--- a/high-compliance/databases-with-trustworthy-on.sql
+++ b/high-compliance/databases-with-trustworthy-on.sql
@@ -1,0 +1,20 @@
+/*
+    databases-with-trustworthy-on.sql
+    Reports databases where TRUSTWORTHY is enabled with additional metadata.
+
+    Refs: CIS SQL Server 3.2
+*/
+SELECT
+    name AS DatabaseName,
+    database_id,
+    containment_desc,
+    state_desc,
+    owner_sid,
+    create_date,
+    is_trustworthy_on,
+    is_db_chaining_on,
+    is_broker_enabled,
+    user_access_desc,
+    recovery_model_desc
+FROM sys.databases
+WHERE is_trustworthy_on = 1;

--- a/high-compliance/jobs-owned-by-non-sa.sql
+++ b/high-compliance/jobs-owned-by-non-sa.sql
@@ -1,0 +1,21 @@
+/*
+    jobs-owned-by-non-sa.sql
+    Finds SQL Agent jobs that are not owned by the sa login and includes job metadata.
+
+    Refs: CIS SQL Server 8.1
+*/
+SELECT
+    j.job_id,
+    j.name AS JobName,
+    sp.name AS JobOwner,
+    j.enabled,
+    j.description,
+    j.date_created,
+    j.date_modified,
+    c.name AS Category
+FROM msdb.dbo.sysjobs AS j
+JOIN sys.server_principals AS sp
+    ON j.owner_sid = sp.sid
+LEFT JOIN msdb.dbo.syscategories AS c
+    ON j.category_id = c.category_id
+WHERE sp.name <> 'sa';

--- a/high-compliance/list-open-endpoints.sql
+++ b/high-compliance/list-open-endpoints.sql
@@ -1,0 +1,21 @@
+/*
+    list-open-endpoints.sql
+    Lists network endpoints that are started and accessible with additional details.
+
+    Refs: CIS SQL Server 4.1
+*/
+SELECT
+    e.endpoint_id,
+    e.name AS EndpointName,
+    e.protocol_desc,
+    e.type_desc,
+    e.state_desc,
+    e.is_admin_endpoint,
+    te.port,
+    te.is_dynamic_port,
+    e.create_date,
+    e.modify_date
+FROM sys.endpoints AS e
+LEFT JOIN sys.tcp_endpoints AS te
+    ON e.endpoint_id = te.endpoint_id
+WHERE e.state_desc = 'STARTED';

--- a/high-compliance/list-orphaned-users.sql
+++ b/high-compliance/list-orphaned-users.sql
@@ -1,0 +1,22 @@
+/*
+    list-orphaned-users.sql
+    Finds database principals that do not have matching server logins with detailed info.
+
+    Refs: CIS SQL Server, ISO 27001 A.9
+*/
+SELECT
+    DB_NAME() AS DatabaseName,
+    dp.principal_id,
+    dp.name AS UserName,
+    dp.type_desc AS UserType,
+    dp.authentication_type_desc,
+    dp.default_schema_name,
+    dp.create_date,
+    dp.modify_date,
+    dp.sid
+FROM sys.database_principals AS dp
+LEFT JOIN sys.server_principals AS sp
+    ON dp.sid = sp.sid
+WHERE sp.sid IS NULL
+  AND dp.type IN ('S', 'U')
+  AND dp.name NOT IN ('guest', 'dbo', 'INFORMATION_SCHEMA', 'sys');

--- a/high-compliance/list-public-role-permissions.sql
+++ b/high-compliance/list-public-role-permissions.sql
@@ -1,0 +1,39 @@
+/*
+    list-public-role-permissions.sql
+    Displays permissions granted to the public role at server and database scope with grantor details.
+
+    Refs: CIS SQL Server 2.5
+*/
+SELECT
+    'SERVER' AS Scope,
+    perm.permission_name,
+    perm.state_desc,
+    perm.class_desc,
+    perm.major_id,
+    perm.minor_id,
+    grantor.name AS Grantor,
+    grantee.name AS Grantee
+FROM sys.server_permissions AS perm
+JOIN sys.server_principals AS grantee
+    ON perm.grantee_principal_id = grantee.principal_id
+JOIN sys.server_principals AS grantor
+    ON perm.grantor_principal_id = grantor.principal_id
+WHERE perm.grantee_principal_id = SUSER_ID('public')
+
+UNION ALL
+
+SELECT
+    'DATABASE' AS Scope,
+    perm.permission_name,
+    perm.state_desc,
+    perm.class_desc,
+    perm.major_id,
+    perm.minor_id,
+    grantor.name AS Grantor,
+    grantee.name AS Grantee
+FROM sys.database_permissions AS perm
+JOIN sys.database_principals AS grantee
+    ON perm.grantee_principal_id = grantee.principal_id
+JOIN sys.database_principals AS grantor
+    ON perm.grantor_principal_id = grantor.principal_id
+WHERE perm.grantee_principal_id = DATABASE_PRINCIPAL_ID('public');

--- a/high-compliance/logins-with-expired-passwords.sql
+++ b/high-compliance/logins-with-expired-passwords.sql
@@ -1,0 +1,20 @@
+/*
+    logins-with-expired-passwords.sql
+    Lists SQL logins that have expired passwords or must change passwords with additional details.
+
+    Refs: CIS SQL Server 2.14
+*/
+SELECT
+    principal_id,
+    name AS LoginName,
+    default_database_name,
+    default_language_name,
+    is_disabled,
+    create_date,
+    modify_date,
+    LOGINPROPERTY(name, 'PasswordLastSetTime') AS PasswordLastSetTime,
+    LOGINPROPERTY(name, 'IsExpired') AS IsExpired,
+    LOGINPROPERTY(name, 'IsMustChange') AS MustChange
+FROM sys.sql_logins
+WHERE LOGINPROPERTY(name, 'IsExpired') = 1
+   OR LOGINPROPERTY(name, 'IsMustChange') = 1;

--- a/high-compliance/logins-without-password-policy.sql
+++ b/high-compliance/logins-without-password-policy.sql
@@ -1,0 +1,20 @@
+/*
+    logins-without-password-policy.sql
+    Finds SQL logins that do not enforce password or expiration policies with additional metadata.
+
+    Refs: CIS SQL Server 2.9
+*/
+SELECT
+    principal_id,
+    name AS LoginName,
+    default_database_name,
+    default_language_name,
+    is_disabled,
+    create_date,
+    modify_date,
+    LOGINPROPERTY(name, 'PasswordLastSetTime') AS PasswordLastSetTime,
+    is_policy_checked,
+    is_expiration_checked
+FROM sys.sql_logins
+WHERE is_policy_checked = 0
+   OR is_expiration_checked = 0;

--- a/high-compliance/procedures-with-execute-as-owner.sql
+++ b/high-compliance/procedures-with-execute-as-owner.sql
@@ -1,0 +1,20 @@
+/*
+    procedures-with-execute-as-owner.sql
+    Lists stored procedures that use EXECUTE AS owner with procedure metadata.
+
+    Refs: CIS SQL Server 5.2
+*/
+SELECT
+    p.object_id,
+    OBJECT_SCHEMA_NAME(p.object_id) AS SchemaName,
+    p.name AS ProcedureName,
+    dp.name AS ExecuteAs,
+    p.create_date,
+    p.modify_date,
+    p.is_ms_shipped,
+    p.uses_ansi_nulls,
+    p.uses_quoted_identifier
+FROM sys.procedures AS p
+JOIN sys.database_principals AS dp
+    ON p.execute_as_principal_id = dp.principal_id
+WHERE p.execute_as_principal_id IS NOT NULL;

--- a/high-compliance/sa-account-status.sql
+++ b/high-compliance/sa-account-status.sql
@@ -1,0 +1,19 @@
+/*
+    sa-account-status.sql
+    Reports status of the sa login with extra details.
+
+    Refs: CIS SQL Server 1.2
+*/
+SELECT
+    principal_id,
+    name AS LoginName,
+    type_desc,
+    default_database_name,
+    default_language_name,
+    is_disabled,
+    create_date,
+    modify_date,
+    LOGINPROPERTY(name, 'BadPasswordCount') AS BadPasswordCount,
+    LOGINPROPERTY(name, 'LastLogonTime') AS LastLogonTime
+FROM sys.server_principals
+WHERE sid = 0x01;

--- a/high-compliance/server-audit-specifications.sql
+++ b/high-compliance/server-audit-specifications.sql
@@ -1,0 +1,20 @@
+/*
+    server-audit-specifications.sql
+    Lists server audit specifications and their status with audited actions.
+
+    Refs: PCI DSS 10.2
+*/
+SELECT
+    sas.server_specification_id,
+    sas.name AS SpecificationName,
+    a.name AS AuditName,
+    sas.is_state_enabled,
+    sas.create_date,
+    sas.modify_date,
+    sad.audit_action_id,
+    sad.audited_result
+FROM sys.server_audit_specifications AS sas
+JOIN sys.server_audits AS a
+    ON sas.audit_guid = a.audit_guid
+LEFT JOIN sys.server_audit_specification_details AS sad
+    ON sas.server_specification_id = sad.server_specification_id;

--- a/high-compliance/xp-cmdshell-usage.sql
+++ b/high-compliance/xp-cmdshell-usage.sql
@@ -1,0 +1,21 @@
+/*
+    xp-cmdshell-usage.sql
+    Searches for modules that reference xp_cmdshell with object metadata.
+
+    Refs: CIS SQL Server 5.1
+*/
+SELECT
+    o.object_id,
+    OBJECT_SCHEMA_NAME(o.object_id) AS SchemaName,
+    o.name AS ObjectName,
+    o.type_desc AS ObjectType,
+    o.create_date,
+    o.modify_date,
+    o.is_ms_shipped,
+    m.uses_ansi_nulls,
+    m.uses_quoted_identifier,
+    m.definition
+FROM sys.sql_modules AS m
+JOIN sys.objects AS o
+    ON m.object_id = o.object_id
+WHERE m.definition LIKE '%xp_cmdshell%';


### PR DESCRIPTION
## Summary
- expand high compliance SQL audit scripts to surface detailed metadata like audit GUIDs, port numbers, principal types and timestamp fields
- include grantor/grantee info and login properties so results return additional rows and columns for deeper compliance analysis

## Testing
- `sqlfluff --version` *(fails: command not found)*
- `pip install sqlfluff` *(fails: Could not find a version that satisfies the requirement sqlfluff (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_6893ad1fe4dc8327918b481b69786eb2