### PR TITLE
Add comprehensive security reporting scripts

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -1,0 +1,5 @@
+# Security Reporting
+
+Scripts in this folder provide comprehensive security reports for SQL Managed Instances and on-prem SQL Server environments.
+
+Use them to audit logins, permissions, role memberships, encryption settings, dynamic data masking, and other security-related aspects across instances and databases. Each script returns an extensive set of columns to deliver deep visibility into security metadata.

--- a/security/active-sessions-security.sql
+++ b/security/active-sessions-security.sql
@@ -1,0 +1,40 @@
+/*
+    active-sessions-security.sql
+    Session information with security context.
+*/
+
+SELECT
+    s.session_id,
+    s.login_name,
+    s.host_name,
+    s.program_name,
+    s.client_interface_name,
+    s.status,
+    s.login_time,
+    s.last_request_start_time,
+    s.last_request_end_time,
+    s.reads,
+    s.writes,
+    s.logical_reads,
+    s.cpu_time,
+    s.memory_usage,
+    s.original_login_name,
+    s.nt_domain,
+    s.nt_user_name,
+    s.is_user_process,
+    s.authentication_scheme,
+    c.net_transport,
+    c.protocol_type,
+    c.encrypt_option,
+    c.auth_scheme,
+    c.client_net_address,
+    c.client_tcp_port,
+    c.local_net_address,
+    c.local_tcp_port,
+    c.connect_time,
+    c.last_read,
+    c.last_write
+FROM sys.dm_exec_sessions AS s
+LEFT JOIN sys.dm_exec_connections AS c
+       ON s.session_id = c.session_id
+ORDER BY s.session_id;

--- a/security/always-encrypted-columns.sql
+++ b/security/always-encrypted-columns.sql
@@ -1,0 +1,49 @@
+/*
+    always-encrypted-columns.sql
+    Always Encrypted configuration info.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       t.schema_id,
+       sch.name AS schema_name,
+       t.name AS table_name,
+       c.name AS column_name,
+       c.column_id,
+       c.is_nullable,
+       TYPE_NAME(c.user_type_id) AS data_type,
+       c.max_length,
+       c.encryption_type_desc,
+       cek.name AS column_encryption_key_name,
+       cek.create_date AS cek_create_date,
+       cek.modify_date AS cek_modify_date,
+       cekv.encryption_algorithm_name,
+       cekv.encryption_type_desc,
+       cekv.encryption_state,
+       cmk.name AS column_master_key_name,
+       cmk.key_store_provider_name,
+       cmk.key_path,
+       cmk.create_date AS cmk_create_date,
+       cmk.modify_date AS cmk_modify_date
+FROM [' + name + '].sys.columns AS c
+JOIN [' + name + '].sys.tables AS t
+     ON c.object_id = t.object_id
+JOIN [' + name + '].sys.schemas AS sch
+     ON t.schema_id = sch.schema_id
+JOIN [' + name + '].sys.column_encryption_key_values AS cekv
+     ON c.column_encryption_key_id = cekv.column_encryption_key_id
+JOIN [' + name + '].sys.column_encryption_keys AS cek
+     ON cekv.column_encryption_key_id = cek.column_encryption_key_id
+JOIN [' + name + '].sys.column_master_keys AS cmk
+     ON cekv.column_master_key_id = cmk.column_master_key_id
+WHERE c.encryption_type IS NOT NULL
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/audit-events-report.sql
+++ b/security/audit-events-report.sql
@@ -1,0 +1,31 @@
+/*
+    audit-events-report.sql
+    Recent audit events (works with file audits). Adjust path as needed.
+*/
+
+SELECT
+    event_time,
+    sequence_number,
+    action_id,
+    succeeded,
+    server_instance_name,
+    server_principal_name,
+    server_principal_sid,
+    database_principal_name,
+    database_principal_id,
+    target_server_principal_name,
+    target_server_principal_sid,
+    target_database_principal_name,
+    target_database_principal_id,
+    object_name,
+    object_id,
+    class_type,
+    session_id,
+    application_name,
+    host_name,
+    client_ip,
+    client_connection_id,
+    statement,
+    additional_information
+FROM sys.fn_get_audit_file('PATH_TO_AUDIT_FILES\\*.sqlaudit', DEFAULT, DEFAULT)
+ORDER BY event_time DESC;

--- a/security/audit-specifications.sql
+++ b/security/audit-specifications.sql
@@ -1,0 +1,44 @@
+/*
+    audit-specifications.sql
+    Server and database audit specifications.
+*/
+
+-- Server audits
+SELECT
+    sa.audit_id,
+    sa.name               AS audit_name,
+    sa.audit_guid,
+    sa.audit_file_path,
+    sa.audit_destination,
+    sa.max_file_size,
+    sa.max_rollover_files,
+    sa.queue_delay,
+    sa.on_failure,
+    sa.is_state_enabled,
+    sa.is_automated_process,
+    sa.principal_id,
+    sa.create_date,
+    sa.modify_date
+FROM sys.server_audits AS sa;
+
+-- Database audits for each database
+DECLARE @sql NVARCHAR(MAX) = N'';
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       da.audit_specification_id,
+       da.audit_specification_guid,
+       da.name AS audit_spec_name,
+       da.is_state_enabled,
+       da.user_defined_predicate,
+       da.principal_id,
+       da.create_date,
+       da.modify_date
+FROM [' + name + '].sys.database_audit_specifications AS da
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/built-in-role-assignments.sql
+++ b/security/built-in-role-assignments.sql
@@ -1,0 +1,27 @@
+/*
+    built-in-role-assignments.sql
+    Built-in server roles and their members for quick review.
+*/
+
+SELECT
+    spr.principal_id AS role_principal_id,
+    spr.name      AS role_name,
+    spr.type_desc AS role_type,
+    spr.is_disabled AS role_disabled,
+    spr.create_date AS role_create_date,
+    spr.modify_date AS role_modify_date,
+    spm.principal_id AS member_principal_id,
+    spm.name      AS member_name,
+    spm.type_desc AS member_type,
+    spm.is_disabled AS member_disabled,
+    spm.default_database_name,
+    spm.default_language_name,
+    spm.create_date,
+    spm.modify_date
+FROM sys.server_role_members AS srm
+JOIN sys.server_principals AS spr
+     ON srm.role_principal_id = spr.principal_id
+JOIN sys.server_principals AS spm
+     ON srm.member_principal_id = spm.principal_id
+WHERE spr.is_fixed_role = 1
+ORDER BY spr.name, spm.name;

--- a/security/certificates-asymmetric-keys.sql
+++ b/security/certificates-asymmetric-keys.sql
@@ -1,0 +1,40 @@
+/*
+    certificates-asymmetric-keys.sql
+    Certificates and asymmetric keys with usage.
+*/
+
+SELECT
+    c.certificate_id        AS object_id,
+    c.name                  AS object_name,
+    'CERTIFICATE'           AS object_type,
+    c.subject,
+    c.start_date,
+    c.expiry_date,
+    c.thumbprint,
+    c.pvt_key_encryption_type_desc,
+    c.is_active_for_begin_dialog,
+    c.is_active_for_database_encryption,
+    sp.principal_id         AS owner_principal_id,
+    sp.name                 AS owner_name,
+    sp.type_desc            AS owner_type
+FROM sys.certificates AS c
+LEFT JOIN sys.database_principals AS sp
+       ON c.principal_id = sp.principal_id
+UNION ALL
+SELECT
+    ak.asymmetric_key_id    AS object_id,
+    ak.name                 AS object_name,
+    'ASYMMETRIC KEY'        AS object_type,
+    NULL                    AS subject,
+    ak.create_date          AS start_date,
+    ak.modify_date          AS expiry_date,
+    NULL                    AS thumbprint,
+    ak.pvt_key_encryption_type_desc,
+    NULL                    AS is_active_for_begin_dialog,
+    NULL                    AS is_active_for_database_encryption,
+    sp.principal_id         AS owner_principal_id,
+    sp.name                 AS owner_name,
+    sp.type_desc            AS owner_type
+FROM sys.asymmetric_keys AS ak
+LEFT JOIN sys.database_principals AS sp
+       ON ak.principal_id = sp.principal_id;

--- a/security/column-permissions-all-dbs.sql
+++ b/security/column-permissions-all-dbs.sql
@@ -1,0 +1,41 @@
+/*
+    column-permissions-all-dbs.sql
+    Column-level permissions for all databases.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       OBJECT_NAME(colperm.major_id, DB_ID(''' + name + ''')) AS table_name,
+       colperm.major_id,
+       colperm.class_desc,
+       colperm.column_id,
+       c.name AS column_name,
+       TYPE_NAME(c.user_type_id) AS data_type,
+       c.max_length,
+       c.precision,
+       c.scale,
+       colperm.permission_name,
+       colperm.state_desc,
+       colperm.grantor_principal_id,
+       grantor.name AS grantor_name,
+       grantee.principal_id AS grantee_principal_id,
+       grantee.name AS grantee_name,
+       grantee.type_desc AS grantee_type
+FROM [' + name + '].sys.column_permissions AS colperm
+JOIN [' + name + '].sys.columns AS c
+     ON colperm.column_id = c.column_id
+    AND colperm.major_id = c.object_id
+JOIN [' + name + '].sys.database_principals AS grantee
+     ON colperm.grantee_principal_id = grantee.principal_id
+LEFT JOIN [' + name + '].sys.database_principals AS grantor
+     ON colperm.grantor_principal_id = grantor.principal_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/database-object-permissions-all-dbs.sql
+++ b/security/database-object-permissions-all-dbs.sql
@@ -1,0 +1,41 @@
+/*
+    database-object-permissions-all-dbs.sql
+    Object-level permissions per database with wide detail.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       dp.class_desc,
+       dp.class,
+       dp.major_id,
+       dp.minor_id,
+       OBJECT_SCHEMA_NAME(dp.major_id, DB_ID(''' + name + ''')) AS schema_name,
+       OBJECT_NAME(dp.major_id, DB_ID(''' + name + ''')) AS object_name,
+       o.type_desc AS object_type,
+       dp.permission_name,
+       dp.state_desc,
+       dp.grantee_principal_id,
+       grantee.name AS grantee_name,
+       grantee.type_desc AS grantee_type,
+       grantee.authentication_type_desc AS grantee_auth,
+       dp.grantor_principal_id,
+       grantor.name AS grantor_name,
+       grantor.type_desc AS grantor_type,
+       grantor.authentication_type_desc AS grantor_auth
+FROM [' + name + '].sys.database_permissions AS dp
+JOIN [' + name + '].sys.database_principals AS grantee
+     ON dp.grantee_principal_id = grantee.principal_id
+JOIN [' + name + '].sys.database_principals AS grantor
+     ON dp.grantor_principal_id = grantor.principal_id
+LEFT JOIN [' + name + '].sys.objects AS o
+     ON dp.major_id = o.object_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/database-principals-all-dbs.sql
+++ b/security/database-principals-all-dbs.sql
@@ -1,0 +1,31 @@
+/*
+    database-principals-all-dbs.sql
+    Database principals for all online databases.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT DB_NAME() AS database_name,
+       dp.principal_id,
+       dp.sid,
+       dp.name,
+       dp.type,
+       dp.type_desc,
+       dp.default_schema_name,
+       dp.default_language_name,
+       dp.owning_principal_id,
+       dp.authentication_type_desc,
+       dp.create_date,
+       dp.modify_date,
+       dp.is_fixed_role
+FROM sys.database_principals AS dp
+WHERE dp.type NOT IN (''A'',''G'',''R'',''X''); -- skip application roles, etc.
+'
++ CHAR(13)+CHAR(10)+'UNION ALL'+CHAR(13)+CHAR(10)
+FROM sys.databases
+WHERE state_desc = 'ONLINE'
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN('UNION ALL')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/database-role-members-all-dbs.sql
+++ b/security/database-role-members-all-dbs.sql
@@ -1,0 +1,31 @@
+/*
+    database-role-members-all-dbs.sql
+    Role membership per database.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       rp.principal_id AS role_principal_id,
+       rp.name AS role_name,
+       rp.type_desc AS role_type,
+       rp.create_date AS role_create_date,
+       mp.principal_id AS member_principal_id,
+       mp.name AS member_name,
+       mp.type_desc AS member_type,
+       mp.authentication_type_desc AS member_auth,
+       mp.create_date AS member_create_date
+FROM [' + name + '].sys.database_role_members AS drm
+JOIN [' + name + '].sys.database_principals AS rp
+     ON drm.role_principal_id = rp.principal_id
+JOIN [' + name + '].sys.database_principals AS mp
+     ON drm.member_principal_id = mp.principal_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/database-scoped-credentials.sql
+++ b/security/database-scoped-credentials.sql
@@ -1,0 +1,31 @@
+/*
+    database-scoped-credentials.sql
+    Database scoped credentials and external users.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       dsc.credential_id,
+       dsc.name AS credential_name,
+       dsc.identity_name,
+       dsc.credential_identity,
+       dsc.provider_name,
+       dsc.target,
+       dsc.create_date,
+       dsc.modify_date,
+       dsc.principal_id,
+       dp.name AS principal_name,
+       dp.type_desc AS principal_type
+FROM [' + name + '].sys.database_scoped_credentials AS dsc
+LEFT JOIN [' + name + '].sys.database_principals AS dp
+       ON dsc.principal_id = dp.principal_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/db-trustworthy-ownership-chain.sql
+++ b/security/db-trustworthy-ownership-chain.sql
@@ -1,0 +1,26 @@
+/*
+    db-trustworthy-ownership-chain.sql
+    Database trustworthy and ownership chain info.
+*/
+
+SELECT
+    d.database_id,
+    d.name           AS database_name,
+    d.state_desc,
+    d.user_access_desc,
+    d.containment_desc,
+    d.recovery_model_desc,
+    d.collation_name,
+    d.owner_sid,
+    sp.name          AS owner_name,
+    d.trustworthy,
+    d.is_db_chaining_on,
+    d.is_encrypted,
+    d.is_read_only,
+    d.log_reuse_wait_desc,
+    d.create_date,
+    d.modify_date
+FROM sys.databases AS d
+LEFT JOIN sys.server_principals AS sp
+       ON d.owner_sid = sp.sid
+ORDER BY d.name;

--- a/security/dynamic-data-masking.sql
+++ b/security/dynamic-data-masking.sql
@@ -1,0 +1,37 @@
+/*
+    dynamic-data-masking.sql
+    Reports dynamic data masking rules.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       t.name AS table_name,
+       c.name AS column_name,
+       c.column_id,
+       TYPE_NAME(c.user_type_id) AS data_type,
+       c.max_length,
+       c.collation_name,
+       c.is_nullable,
+       mc.masking_function,
+       mc.is_masked,
+       mc.ordinal,
+       f.masking_function AS masking_function_name,
+       f.definition
+FROM [' + name + '].sys.masked_columns AS mc
+JOIN [' + name + '].sys.tables AS t
+     ON mc.object_id = t.object_id
+JOIN [' + name + '].sys.columns AS c
+     ON mc.column_id = c.column_id
+    AND mc.object_id = c.object_id
+LEFT JOIN [' + name + '].sys.masking_functions AS f
+     ON mc.masking_function_id = f.masking_function_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/endpoint-permissions.sql
+++ b/security/endpoint-permissions.sql
@@ -1,0 +1,33 @@
+/*
+    endpoint-permissions.sql
+    Endpoint definitions and permissions.
+*/
+
+SELECT
+    e.endpoint_id,
+    e.name AS endpoint_name,
+    e.principal_id,
+    e.owner_sid,
+    e.type_desc,
+    e.protocol_desc,
+    e.state_desc,
+    e.is_admin_endpoint,
+    e.create_date,
+    e.modify_date,
+    sp.major_id,
+    sp.permission_name,
+    sp.state_desc,
+    sp.class_desc,
+    sp.grantor_principal_id,
+    grantor.name AS grantor_name,
+    grantee.principal_id AS grantee_principal_id,
+    grantee.name AS grantee_name
+FROM sys.endpoints AS e
+LEFT JOIN sys.server_permissions AS sp
+     ON e.endpoint_id = sp.major_id
+    AND sp.class_desc = 'ENDPOINT'
+LEFT JOIN sys.server_principals AS grantee
+     ON sp.grantee_principal_id = grantee.principal_id
+LEFT JOIN sys.server_principals AS grantor
+     ON sp.grantor_principal_id = grantor.principal_id
+ORDER BY e.name;

--- a/security/job-owners-proxy.sql
+++ b/security/job-owners-proxy.sql
@@ -1,0 +1,32 @@
+/*
+    job-owners-proxy.sql
+    SQL Agent job owners and proxy accounts (run in msdb).
+*/
+
+USE msdb;
+SELECT
+    j.job_id,
+    j.name AS job_name,
+    j.enabled,
+    j.owner_sid,
+    sp.name AS owner_name,
+    j.description,
+    j.category_id,
+    j.date_created,
+    j.date_modified,
+    j.notify_email_operator_id,
+    ja.step_id,
+    ja.step_name,
+    ja.subsystem,
+    ja.proxy_id,
+    p.name AS proxy_name,
+    p.credential_id,
+    p.enabled AS proxy_enabled
+FROM dbo.sysjobs AS j
+LEFT JOIN master.sys.server_principals AS sp
+       ON j.owner_sid = sp.sid
+LEFT JOIN dbo.sysjobsteps AS ja
+       ON j.job_id = ja.job_id
+LEFT JOIN dbo.sysproxies AS p
+       ON ja.proxy_id = p.proxy_id
+ORDER BY j.name;

--- a/security/linked-servers-security.sql
+++ b/security/linked-servers-security.sql
@@ -1,0 +1,35 @@
+/*
+    linked-servers-security.sql
+    Linked servers with security details.
+*/
+
+SELECT
+    ls.server_id,
+    ls.name            AS linked_server_name,
+    ls.product,
+    ls.provider,
+    ls.data_source,
+    ls.location,
+    ls.catalog,
+    ls.is_collation_compatible,
+    ls.uses_remote_collation,
+    ls.is_data_access_enabled,
+    ls.is_rpc_out_enabled,
+    ls.is_rpc_enabled,
+    ls.is_remote_login_enabled,
+    ls.connect_timeout,
+    ls.query_timeout,
+    ls.modify_date,
+    ssp.local_principal_id,
+    sp.name            AS local_principal_name,
+    ssp.credential_id,
+    ssp.uses_self_credential,
+    ssp.remote_name,
+    ssp.modify_date    AS login_modify_date
+FROM sys.servers AS ls
+LEFT JOIN sys.linked_logins AS ssp
+       ON ls.server_id = ssp.server_id
+LEFT JOIN sys.server_principals AS sp
+       ON ssp.local_principal_id = sp.principal_id
+WHERE ls.is_linked = 1
+ORDER BY ls.name;

--- a/security/orphaned-db-users.sql
+++ b/security/orphaned-db-users.sql
@@ -1,0 +1,30 @@
+/*
+    orphaned-db-users.sql
+    Orphaned users per database.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       dp.principal_id,
+       dp.name AS user_name,
+       dp.type_desc,
+       dp.sid,
+       dp.default_schema_name,
+       dp.authentication_type_desc,
+       dp.create_date,
+       dp.modify_date
+FROM [' + name + '].sys.database_principals AS dp
+LEFT JOIN sys.server_principals AS sp
+       ON dp.sid = sp.sid
+WHERE dp.type_desc IN (''SQL_USER'',''WINDOWS_USER'')
+  AND sp.sid IS NULL
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/row-level-security-policies.sql
+++ b/security/row-level-security-policies.sql
@@ -1,0 +1,38 @@
+/*
+    row-level-security-policies.sql
+    Row-level security policies and predicate functions.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       sp.object_id AS policy_object_id,
+       sp.name AS policy_name,
+       sp.schema_id,
+       sch.name AS schema_name,
+       sp.is_enabled,
+       sp.is_schema_bound,
+       sp.create_date,
+       sp.modify_date,
+       p.security_predicate_id,
+       p.type_desc AS predicate_type,
+       p.operation_desc,
+       p.predicate_definition,
+       p.target_object_id,
+       OBJECT_SCHEMA_NAME(p.target_object_id, DB_ID(''' + name + ''')) AS target_schema,
+       OBJECT_NAME(p.target_object_id, DB_ID(''' + name + ''')) AS target_table,
+       p.filter_column_id
+FROM [' + name + '].sys.security_policies AS sp
+JOIN [' + name + '].sys.schemas AS sch
+     ON sp.schema_id = sch.schema_id
+JOIN [' + name + '].sys.security_predicates AS p
+     ON sp.object_id = p.object_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/schema-ownership-permissions.sql
+++ b/security/schema-ownership-permissions.sql
@@ -1,0 +1,41 @@
+/*
+    schema-ownership-permissions.sql
+    Schemas with owners and permissions.
+*/
+
+DECLARE @sql NVARCHAR(MAX) = N'';
+
+SELECT @sql = @sql +
+'SELECT ''' + name + ''' AS database_name,
+       s.schema_id,
+       s.name AS schema_name,
+       s.principal_id AS owner_principal_id,
+       dp.name AS owner_name,
+       dp.type_desc AS owner_type,
+       s.create_date,
+       s.modify_date,
+       perm.permission_name,
+       perm.state_desc,
+       perm.grantor_principal_id,
+       grantor.name AS grantor_name,
+       grantee.principal_id AS grantee_principal_id,
+       grantee.name AS grantee_name,
+       grantee.type_desc AS grantee_type
+FROM [' + name + '].sys.schemas AS s
+JOIN [' + name + '].sys.database_principals AS dp
+     ON s.principal_id = dp.principal_id
+LEFT JOIN [' + name + '].sys.database_permissions AS perm
+     ON perm.major_id = s.schema_id
+    AND perm.class = 3
+LEFT JOIN [' + name + '].sys.database_principals AS grantee
+     ON perm.grantee_principal_id = grantee.principal_id
+LEFT JOIN [' + name + '].sys.database_principals AS grantor
+     ON perm.grantor_principal_id = grantor.principal_id
+UNION ALL
+'
+FROM sys.databases
+WHERE state_desc = ''ONLINE''
+  AND database_id > 4;
+
+SET @sql = LEFT(@sql, LEN(@sql)-LEN(''UNION ALL'')-2);
+EXEC sys.sp_executesql @sql;

--- a/security/server-credentials.sql
+++ b/security/server-credentials.sql
@@ -1,0 +1,16 @@
+/*
+    server-credentials.sql
+    Server-level credentials.
+*/
+
+SELECT
+    credential_id,
+    name           AS credential_name,
+    credential_identity,
+    target,
+    target_id,
+    target_type,
+    create_date,
+    modify_date
+FROM sys.credentials
+ORDER BY name;

--- a/security/server-permissions.sql
+++ b/security/server-permissions.sql
@@ -1,0 +1,29 @@
+/*
+    server-permissions.sql
+    Detailed server-level permissions.
+*/
+
+SELECT
+    dp.grantee_principal_id,
+    sp.name           AS grantee_name,
+    sp.type_desc      AS grantee_type,
+    sp.sid            AS grantee_sid,
+    dp.class_desc,
+    dp.class,
+    dp.major_id,
+    dp.minor_id,
+    dp.permission_name,
+    dp.state_desc,
+    dp.grantor_principal_id,
+    gp.name           AS grantor_name,
+    gp.type_desc      AS grantor_type,
+    obj.name          AS object_name,
+    obj.type_desc     AS object_type
+FROM sys.server_permissions AS dp
+LEFT JOIN sys.server_principals AS sp
+       ON dp.grantee_principal_id = sp.principal_id
+LEFT JOIN sys.server_principals AS gp
+       ON dp.grantor_principal_id = gp.principal_id
+LEFT JOIN sys.server_principals AS obj
+       ON dp.major_id = obj.principal_id
+ORDER BY sp.name, dp.permission_name;

--- a/security/server-principals-and-roles.sql
+++ b/security/server-principals-and-roles.sql
@@ -1,0 +1,34 @@
+/*
+    server-principals-and-roles.sql
+    Comprehensive server principals list, including role membership and login policy information.
+*/
+
+SELECT
+    sp.principal_id,
+    sp.sid,
+    sp.name               AS principal_name,
+    sp.type_desc          AS principal_type,
+    sp.default_database_name,
+    sp.default_language_name,
+    sp.owning_principal_id,
+    sp.credential_id,
+    sp.is_fixed_role,
+    sp.is_disabled,
+    sp.create_date,
+    sp.modify_date,
+    sp.authentication_type_desc,
+    sl.is_policy_checked,
+    sl.is_expiration_checked,
+    sl.password_hash,
+    sl.password_last_set_time,
+    sl.lockout_time,
+    spr.principal_id       AS role_principal_id,
+    spr.name               AS role_name
+FROM sys.server_principals AS sp
+LEFT JOIN sys.sql_logins AS sl
+       ON sp.principal_id = sl.principal_id
+LEFT JOIN sys.server_role_members AS srm
+       ON sp.principal_id = srm.member_principal_id
+LEFT JOIN sys.server_principals AS spr
+       ON srm.role_principal_id = spr.principal_id
+ORDER BY sp.type_desc, sp.name;

--- a/security/server-role-members.sql
+++ b/security/server-role-members.sql
@@ -1,0 +1,24 @@
+/*
+    server-role-members.sql
+    Report of server role membership with both role and member details.
+*/
+
+SELECT
+    srm.role_principal_id,
+    rp.name AS role_name,
+    rp.type_desc AS role_type,
+    rp.create_date AS role_create_date,
+    srm.member_principal_id,
+    mp.name AS member_name,
+    mp.type_desc AS member_type,
+    mp.is_disabled,
+    mp.default_database_name,
+    mp.default_language_name,
+    mp.create_date,
+    mp.modify_date
+FROM sys.server_role_members AS srm
+JOIN sys.server_principals AS rp
+     ON srm.role_principal_id = rp.principal_id
+JOIN sys.server_principals AS mp
+     ON srm.member_principal_id = mp.principal_id
+ORDER BY rp.name, mp.name;

--- a/security/sql-logins-policy-status.sql
+++ b/security/sql-logins-policy-status.sql
@@ -1,0 +1,24 @@
+/*
+    sql-logins-policy-status.sql
+    SQL logins with password and policy settings.
+*/
+
+SELECT
+    principal_id,
+    sid,
+    name,
+    type_desc,
+    is_disabled,
+    default_database_name,
+    default_language_name,
+    credential_id,
+    owning_principal_id,
+    create_date,
+    modify_date,
+    password_hash,
+    password_last_set_time,
+    is_policy_checked,
+    is_expiration_checked,
+    locked_out
+FROM sys.sql_logins
+ORDER BY name;

--- a/security/tde-status.sql
+++ b/security/tde-status.sql
@@ -1,0 +1,25 @@
+/*
+    tde-status.sql
+    Transparent Data Encryption status per database.
+*/
+
+SELECT
+    d.database_id,
+    d.name          AS database_name,
+    d.state_desc,
+    d.user_access_desc,
+    d.recovery_model_desc,
+    d.collation_name,
+    d.is_encrypted,
+    d.is_read_only,
+    d.create_date,
+    dm.encryption_state,
+    dm.encryptor_type,
+    dm.encryptor_thumbprint,
+    dm.percent_complete,
+    dm.key_algorithm,
+    dm.key_length
+FROM sys.databases AS d
+LEFT JOIN sys.dm_database_encryption_keys AS dm
+       ON d.database_id = dm.database_id
+ORDER BY d.name;


### PR DESCRIPTION
## Summary
- widen server principals/roles query with SIDs, ownership and password policy columns
- enrich column and object permission scripts with data type, grantor and schema details
- add more encryption, audit and session metadata to TDE, audit, and connection reports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894137b864c8327a92c68a83338726e